### PR TITLE
Dockerfile added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM fedora:latest
+
+VOLUME /config
+WORKDIR /usr/src/app
+
+RUN dnf install glib2-devel make gcc -y && \
+    pip3 install --no-cache-dir mitemp_bt bluepy paho-mqtt && \
+    dnf clean all
+
+RUN groupadd -g 9999 appuser && \
+    useradd -r -u 9999 -g appuser appuser && \
+    chown appuser.appuser /usr/src/app/
+USER appuser
+
+COPY . /usr/src/app/
+
+CMD [ "/usr/src/app/run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+for file in "mqtt" "devices" "averages"; do
+  [ -f /config/${file}.ini ] && cp -f /config/${file}.ini /usr/src/app/
+done
+exec "/usr/bin/python3" "/usr/src/app/data-read.py"


### PR DESCRIPTION
There are a few things to do to improve the dockerfile:

- Use requisites.txt instead manually installing the python required dependencies
- Add some flags to specify the mqtt.ini and devices.ini files
- Add some notes about the averages.ini file

It seems to work:

```shell
podman build . -t xiaomi-ble-mqtt

podman run --net=host --rm -v /home/edu/tmp/:/config:Z localhost/xiaomi-ble-mqtt
2019-06-29 20:52:37.255590 salon  :  {"temperature": 26.6, "humidity": 30.0, "battery": 100}
```

(I use podman instead docker but it works the same :+1: )